### PR TITLE
basket sticky적용오류(home.css secion overflow-x:hidden -> store_common.css)

### DIFF
--- a/HomeFriends/src/main/webapp/WEB-INF/views/mypage/basket.jsp
+++ b/HomeFriends/src/main/webapp/WEB-INF/views/mypage/basket.jsp
@@ -29,7 +29,7 @@
 	
 	<link href="${pageContext.request.contextPath}/css/header.css" rel="stylesheet">
 	<link href="${pageContext.request.contextPath}/css/nav.css" rel="stylesheet">
-	<link href="${pageContext.request.contextPath}/css/home.css" rel="stylesheet">
+	<link href="${pageContext.request.contextPath}/css/store/store_common.css" rel="stylesheet">
 	<link href="${pageContext.request.contextPath}/css/footer.css" rel="stylesheet">
 	<link href="${pageContext.request.contextPath}/css/mypage/basket.css" rel="stylesheet">
 	


### PR DESCRIPTION
basket sticky 오류
기존 home.css이용 중 secion에 overflow-x:hidden추가됨으로 인한 sticky작동오류
overflow를 뺀 store_common.css로 변경